### PR TITLE
PR 1/11: Fix PHPStan level 6 errors in 5 entity classes

### DIFF
--- a/src/Entity/Account.php
+++ b/src/Entity/Account.php
@@ -23,6 +23,9 @@ class Account
     #[ORM\Column(type: 'string', length: 255, unique: true)]
     protected ?string $name = null;
 
+    /**
+     * @var array<int, string>
+     */
     #[ORM\Column(type: 'simple_array', nullable: true)]
     #[Assert\Unique(message: 'There are duplicated aliases')]
     protected array $aliases = [];
@@ -52,11 +55,17 @@ class Account
         return $this;
     }
 
+    /**
+     * @return array<int, string>|null
+     */
     public function getAliases(): ?array
     {
         return $this->aliases;
     }
 
+    /**
+     * @param array<int, string>|null $aliases
+     */
     public function setAliases(?array $aliases): self
     {
         $this->aliases = $aliases;

--- a/src/Entity/Operator.php
+++ b/src/Entity/Operator.php
@@ -8,6 +8,9 @@ abstract class Operator
     public const GREATER_THAN_OR_EQUAL = 'greater than or equal';
     public const LOWER_THAN_OR_EQUAL = 'lower than or equal';
 
+    /**
+     * @return array<int, string>
+     */
     public static function getAll(): array
     {
         return [

--- a/src/Entity/SubCategory.php
+++ b/src/Entity/SubCategory.php
@@ -27,9 +27,15 @@ class SubCategory
     #[ORM\JoinColumn(nullable: false)]
     protected ?TopCategory $topCategory = null;
 
+    /**
+     * @var Collection<int, Transaction>
+     */
     #[ORM\OneToMany(targetEntity: Transaction::class, mappedBy: 'subCategory')]
     protected $transactions;
 
+    /**
+     * @var Collection<int, SubCategoryTransactionRule>
+     */
     #[ORM\OneToMany(targetEntity: SubCategoryTransactionRule::class, mappedBy: 'subCategory')]
     protected $subCategoryTransactionRules;
 
@@ -78,7 +84,7 @@ class SubCategory
     }
 
     /**
-     * @return Collection|Transaction[]
+     * @return Collection<int, Transaction>
      */
     public function getTransactions(): Collection
     {
@@ -109,7 +115,7 @@ class SubCategory
     }
 
     /**
-     * @return Collection|SubCategoryTransactionRule[]
+     * @return Collection<int, SubCategoryTransactionRule>
      */
     public function getSubCategoryTransactionRules(): Collection
     {

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -20,6 +20,9 @@ class Tag
     #[ORM\Column(length: 255)]
     protected ?string $name = null;
 
+    /**
+     * @var Collection<int, Transaction>
+     */
     #[ORM\ManyToMany(targetEntity: Transaction::class, inversedBy: 'tags')]
     protected Collection $transactions;
 

--- a/src/Entity/TopCategory.php
+++ b/src/Entity/TopCategory.php
@@ -18,11 +18,14 @@ class TopCategory
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
-    protected $id;
+    protected ?string $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
     protected ?string $name = null;
 
+    /**
+     * @var Collection<int, SubCategory>
+     */
     #[ORM\OneToMany(targetEntity: SubCategory::class, mappedBy: 'topCategory')]
     protected $subCategories;
 
@@ -57,7 +60,7 @@ class TopCategory
     }
 
     /**
-     * @return Collection|SubCategory[]
+     * @return Collection<int, SubCategory>
      */
     public function getSubCategories(): Collection
     {


### PR DESCRIPTION
# PR 1/11: Fix PHPStan level 6 errors in 5 entity classes

**Branch:** `phpstan-level-6-entities-1`
**Base branch:** `phpstan-level-6`
**Files changed (5):** `src/Entity/Account.php`, `src/Entity/Operator.php`, `src/Entity/SubCategory.php`, `src/Entity/Tag.php`, `src/Entity/TopCategory.php`

## Summary

Adds the missing property, parameter, and return types that PHPStan level 6 flags in these five entity classes (12 errors total). All fixes are additive PHPDoc/type annotations — no behavioral changes.

## Details and reasoning

**`Account::$aliases` (property, getter, setter)** — PHPStan's `missingType.iterableValue` fires because `array $aliases` doesn't say what's *in* the array. I documented it as `array<int, string>` via PHPDoc rather than a native `array<string>` type hint (PHP has no native generic array syntax, so PHPDoc is the only option here). I chose `string` as the value type by checking every caller: `AccountRepository` does `LIKE :alias` string matching, `AccountType` form uses a `CollectionType` of plain values, and the Doctrine column type is `simple_array`, which Doctrine always hydrates as a flat array of strings. There's no other type it could reasonably be.

**`Operator::getAll()`** — Returns the class's own `EQUALS` / `GREATER_THAN_OR_EQUAL` / `LOWER_THAN_OR_EQUAL` constants, which are all string literals, so `array<int, string>` was the unambiguous choice.

**`SubCategory::$transactions` / `$subCategoryTransactionRules` and their getters** — These already had PHPDoc, but in the legacy shorthand style `Collection|Transaction[]`, which PHPStan level 6 doesn't accept as satisfying its generics requirement (`missingType.generics`). I converted these to the current `Collection<int, Transaction>` generic syntax, which is the same fix applied everywhere else in this batch and is the idiomatic PHPStan/Doctrine annotation today.

**`Tag::$transactions`** — Same generics fix; this property already had a native `Collection` type hint, it was just missing the `<int, Transaction>` generic parameters in its PHPDoc.

**`TopCategory::$id`** — This was the one property in the whole batch with *no* type at all (native or PHPDoc): `protected $id;`. Every sibling entity in this codebase (`Account`, `SubCategory`, `Tag`) types its Doctrine `uuid` id column as `?string`, so I matched that existing convention rather than inventing a new one.

**`TopCategory::$subCategories` and `getSubCategories()`** — Same `Collection<int, SubCategory>` generics fix as the `SubCategory` properties above.

## Why PHPDoc-only typing for the Doctrine collections (not a native `Collection` type hint)

I deliberately left `SubCategory::$transactions`, `SubCategory::$subCategoryTransactionRules`, and `TopCategory::$subCategories` as *untyped* native properties with PHPDoc-only `@var` annotations, rather than adding a native `protected Collection $transactions` type hint (which `Tag::$transactions` already has, for comparison).

The reason: `SubCategory::$subCategoryTransactionRules` and `TopCategory::$subCategories`/`SubCategory::$transactions` follow the classic Doctrine pattern where collections on the *inverse* side of a relation are populated by Doctrine's reflection-based hydration, not always by the constructor. Specifically, `SubCategory::__construct()` only initializes `$this->transactions`, and leaves `$subCategoryTransactionRules` uninitialized — Doctrine sets it directly via reflection when the entity is loaded from the database. If I added a native non-nullable `Collection` type hint to an uninitialized property, PHP would throw `Error: Typed property must not be accessed before initialization` the moment anyone called `getSubCategoryTransactionRules()` on a freshly-`new`-ed (not-yet-persisted) `SubCategory` — e.g. in a form or a test fixture that builds one manually before saving. PHPDoc-only typing gives PHPStan everything it needs without touching runtime semantics or risking that regression. Where there was no such risk (`TopCategory::$id`, which is a scalar always safely nullable), I used a native type hint instead, since that's strictly better (IDE support, runtime enforcement) and there was no init-order hazard.

## Verification

```
vendor/bin/phpstan analyse src/Entity/Account.php src/Entity/Operator.php src/Entity/SubCategory.php src/Entity/Tag.php src/Entity/TopCategory.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run confirms these are the *only* 12 errors that disappeared;
# no new errors were introduced elsewhere by tightening these types.
```
