### PR TITLE
PR 2/11: Fix PHPStan level 6 errors in Transaction entity, exceptions, and a fixture

### DIFF
--- a/src/DataFixtures/SubCategoryFixtures.php
+++ b/src/DataFixtures/SubCategoryFixtures.php
@@ -12,7 +12,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SubCategoryFixtures extends Fixture implements DependentFixtureInterface
 {
-    private $translator;
+    private TranslatorInterface $translator;
 
     public function __construct(TranslatorInterface $translator)
     {

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -28,10 +28,10 @@ class Transaction
     protected ?float $amount = null;
 
     #[ORM\Column(type: 'boolean', options: ['default' => 1])]
-    protected $toSyncInElasticsearch;
+    protected bool $toSyncInElasticsearch;
 
     #[ORM\Column(type: 'boolean', options: ['default' => 0])]
-    protected $categorizedManually = false;
+    protected bool $categorizedManually = false;
 
     #[ORM\Column(type: 'datetime')]
     protected ?\DateTime $createdAt = null;
@@ -41,8 +41,11 @@ class Transaction
 
     #[ORM\ManyToOne(targetEntity: SubCategory::class, inversedBy: 'transactions')]
     #[ORM\JoinColumn(onDelete: 'SET NULL')]
-    protected $subCategory;
+    protected ?SubCategory $subCategory = null;
 
+    /**
+     * @var Collection<int, Tag>
+     */
     #[ORM\ManyToMany(targetEntity: Tag::class, mappedBy: 'transactions')]
     protected Collection $tags;
 

--- a/src/Entity/TransactionType.php
+++ b/src/Entity/TransactionType.php
@@ -7,6 +7,9 @@ abstract class TransactionType
     public const EXPENSES = 'Expenses';
     public const REVENUES = 'Revenues';
 
+    /**
+     * @return array<int, string>
+     */
     public static function getAll(): array
     {
         return [

--- a/src/Exception/AccountNotFoundException.php
+++ b/src/Exception/AccountNotFoundException.php
@@ -4,7 +4,7 @@ namespace App\Exception;
 
 class AccountNotFoundException extends \Exception
 {
-    private $search;
+    private string $search;
 
     public function __construct(string $search)
     {

--- a/src/Exception/TransactionMatchesMultipleRulesException.php
+++ b/src/Exception/TransactionMatchesMultipleRulesException.php
@@ -7,10 +7,16 @@ use App\Entity\Transaction;
 
 class TransactionMatchesMultipleRulesException extends \Exception
 {
-    private $transaction;
+    private Transaction $transaction;
 
-    private $rules;
+    /**
+     * @var array<int, SubCategoryTransactionRule>
+     */
+    private array $rules;
 
+    /**
+     * @param array<int, SubCategoryTransactionRule> $rules
+     */
     public function __construct(Transaction $transaction, array $rules)
     {
         $this->transaction = $transaction;


### PR DESCRIPTION
# PR 2/11: Fix PHPStan level 6 errors in Transaction entity, exceptions, and a fixture

**Branch:** `phpstan-level-6-entities-2`
**Base branch:** `phpstan-level-6-entities-1`
**Files changed (5):** `src/Entity/Transaction.php`, `src/Entity/TransactionType.php`, `src/Exception/TransactionMatchesMultipleRulesException.php`, `src/Exception/AccountNotFoundException.php`, `src/DataFixtures/SubCategoryFixtures.php`

## Summary

Adds the missing property, parameter, and return types PHPStan level 6 flags in these five files (10 errors total).

## Details and reasoning

**`Transaction::$toSyncInElasticsearch` / `$categorizedManually`** — Both are plain booleans, and both are always initialized: `$toSyncInElasticsearch` in the constructor (`$this->toSyncInElasticsearch = true;`), `$categorizedManually` via its own `= false` default. Unlike the Doctrine `Collection` properties fixed in PR 1, there's no "Doctrine hydrates this via reflection before the constructor runs" hazard for a scalar with a default — so I used a native `bool` type hint rather than PHPDoc-only, which is strictly better (PHP itself will now enforce the type).

**`Transaction::$subCategory`** — Native `?SubCategory` type hint. Both `getSubCategory()` and `setSubCategory(?SubCategory $subCategory)` already treat this as nullable, so the property type just needed to catch up to how it's actually used.

**`Transaction::$tags`** — Same situation as `Tag::$transactions` from PR 1: it already had a native `Collection` type hint, just missing the `<int, Tag>` generic parameters in PHPDoc.

**`TransactionType::getAll()`** — `array<int, string>` PHPDoc. Same reasoning as `Operator::getAll()` in PR 1 — it returns the class's own string constants (`EXPENSES`, `REVENUES`), so the value type is unambiguous.

**`TransactionMatchesMultipleRulesException::$transaction`** — Native `Transaction` (non-nullable) type hint. It's a required constructor parameter, assigned once, and never treated as optional anywhere in the class.

**`TransactionMatchesMultipleRulesException::$rules` (property and constructor parameter)** — Documented as `array<int, SubCategoryTransactionRule>`. I matched this to the existing `getRules(): SubCategoryTransactionRule[]` docblock, which PHPStan already accepted — the property and the constructor parameter simply hadn't been given the same annotation the getter already had.

**`AccountNotFoundException::$search`** — Native `string` type hint. Always assigned from a required `string $search` constructor parameter.

**`SubCategoryFixtures::$translator`** — Native `TranslatorInterface` type hint. Standard constructor-injected dependency, always set; the exact same pattern used by `TopCategoryFixtures` (fixed in PR 3) and several other classes across this codebase.

## Verification

```
vendor/bin/phpstan analyse src/Entity/Transaction.php src/Entity/TransactionType.php \
  src/Exception/TransactionMatchesMultipleRulesException.php \
  src/Exception/AccountNotFoundException.php \
  src/DataFixtures/SubCategoryFixtures.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run: exactly these 10 errors disappeared, no new errors introduced.
```
