### PR TITLE
PR 3/11: Fix PHPStan level 6 errors in event classes and a fixture

### DIFF
--- a/src/DataFixtures/TopCategoryFixtures.php
+++ b/src/DataFixtures/TopCategoryFixtures.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TopCategoryFixtures extends Fixture
 {
-    private $translator;
+    private TranslatorInterface $translator;
 
     public function __construct(TranslatorInterface $translator)
     {

--- a/src/Event/TransactionCategoryChangedEvent.php
+++ b/src/Event/TransactionCategoryChangedEvent.php
@@ -10,9 +10,9 @@ class TransactionCategoryChangedEvent extends Event
 {
     public const NAME = 'transaction.category_changed';
 
-    private $oldSubCategory;
+    private SubCategory $oldSubCategory;
 
-    private $transaction;
+    private Transaction $transaction;
 
     public function __construct(Transaction $transaction, SubCategory $oldSubCategory)
     {

--- a/src/Event/TransactionExportedEvent.php
+++ b/src/Event/TransactionExportedEvent.php
@@ -9,10 +9,16 @@ class TransactionExportedEvent extends Event
 {
     public const NAME = 'transaction.exported';
 
+    /**
+     * @var array<string, mixed>
+     */
     private array $response;
 
     private Transaction $transaction;
 
+    /**
+     * @param array<string, mixed> $response
+     */
     public function __construct(Transaction $transaction, array $response)
     {
         $this->transaction = $transaction;

--- a/src/Event/TransactionMatchesMultipleRulesEvent.php
+++ b/src/Event/TransactionMatchesMultipleRulesEvent.php
@@ -10,9 +10,16 @@ class TransactionMatchesMultipleRulesEvent extends Event
 {
     public const NAME = 'transaction.matches_multiple_rules';
 
-    protected $transaction;
-    protected $rules;
+    protected Transaction $transaction;
 
+    /**
+     * @var array<int, SubCategoryTransactionRule>
+     */
+    protected array $rules;
+
+    /**
+     * @param array<int, SubCategoryTransactionRule> $rules
+     */
     public function __construct(Transaction $transaction, array $rules)
     {
         $this->rules = $rules;

--- a/src/Event/TransactionsExportingEvent.php
+++ b/src/Event/TransactionsExportingEvent.php
@@ -8,7 +8,7 @@ class TransactionsExportingEvent extends Event
 {
     public const NAME = 'transactions.exporting';
 
-    protected $transactionCount;
+    protected int $transactionCount;
 
     public function __construct(int $transactionCount)
     {


### PR DESCRIPTION
# PR 3/11: Fix PHPStan level 6 errors in event classes and a fixture

**Branch:** `phpstan-level-6-events-fixtures`
**Base branch:** `phpstan-level-6-entities-2`
**Files changed (5):** `src/DataFixtures/TopCategoryFixtures.php`, `src/Event/TransactionMatchesMultipleRulesEvent.php`, `src/Event/TransactionExportedEvent.php`, `src/Event/TransactionCategoryChangedEvent.php`, `src/Event/TransactionsExportingEvent.php`

## Summary

Adds the missing property and parameter types PHPStan level 6 flags in these five files (9 errors total). This batch is almost entirely mechanical — every one of these classes follows the same "immutable event/fixture with constructor-assigned, never-reassigned properties" shape already fixed elsewhere in this PR series.

## Details and reasoning

**`TopCategoryFixtures::$translator`** — Native `TranslatorInterface` type hint. Identical to `SubCategoryFixtures::$translator` fixed in PR 2 (same constructor-injection pattern, same class of fixture).

**`TransactionMatchesMultipleRulesEvent::$transaction` / `$rules`** — This class is essentially a duplicate of `TransactionMatchesMultipleRulesException` (fixed in PR 2): same constructor signature, same `getRules(): SubCategoryTransactionRule[]` docblock already in place. I applied the identical fix — native `Transaction` type for `$transaction`, and `array<int, SubCategoryTransactionRule>` PHPDoc for `$rules` on both the property and the constructor parameter, so the annotation is consistent end-to-end rather than only living on the getter.

**`TransactionExportedEvent::$response` (property and constructor parameter)** — Documented as `array<string, mixed>`, matching the `getResponse(): array<string, mixed>` docblock this class already had (only the getter was previously annotated). I confirmed this value type by checking the one place that constructs this event, `Services/Exporter/ElasticsearchExporter.php`, which builds `$response` as an associative array from an Elasticsearch client call.

**`TransactionCategoryChangedEvent::$oldSubCategory` / `$transaction`** — Native `SubCategory` / `Transaction` type hints. Both are required, non-nullable constructor parameters, and both getters (`getTransaction()`, `getOldSubCategory()`) already declare non-nullable return types, so the property types just needed to match.

**`TransactionsExportingEvent::$transactionCount`** — Native `int` type hint, matching the already-typed `int $transactionCount` constructor parameter and the `int` return type of `getTransactionCount()`.

## Verification

```
vendor/bin/phpstan analyse src/DataFixtures/TopCategoryFixtures.php \
  src/Event/TransactionMatchesMultipleRulesEvent.php \
  src/Event/TransactionExportedEvent.php \
  src/Event/TransactionCategoryChangedEvent.php \
  src/Event/TransactionsExportingEvent.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run: exactly these 9 errors disappeared, no new errors introduced.
```
