### PR TITLE
PR 4/11: Fix PHPStan level 6 errors in an event, an argument resolver, and 3 commands

### DIFF
--- a/src/ArgumentResolver/RequestParameterValueResolver.php
+++ b/src/ArgumentResolver/RequestParameterValueResolver.php
@@ -8,6 +8,9 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 class RequestParameterValueResolver implements ValueResolverInterface
 {
+    /**
+     * @return iterable<int, bool|string>
+     */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
         $argumentName = $argument->getName();

--- a/src/Command/CategorizeTransactionsCommand.php
+++ b/src/Command/CategorizeTransactionsCommand.php
@@ -13,8 +13,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 #[AsCommand(name: 'app:categorize-transactions')]
 class CategorizeTransactionsCommand extends Command implements EventSubscriberInterface
 {
-    private $transactionCategorizer;
-    private $output;
+    private TransactionCategorizer $transactionCategorizer;
+    private ?OutputInterface $output = null;
 
     public function __construct(TransactionCategorizer $transactionCategorizer)
     {

--- a/src/Command/ExportModulImmoDataCommand.php
+++ b/src/Command/ExportModulImmoDataCommand.php
@@ -48,7 +48,10 @@ class ExportModulImmoDataCommand extends Command
         return self::SUCCESS;
     }
 
-    private function createRecord($data, $keyword): void
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function createRecord(array $data, string $keyword): void
     {
         $params = [
             'index' => 'modulimmo',

--- a/src/Command/StartWebSocketServerCommand.php
+++ b/src/Command/StartWebSocketServerCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:start-web-socket-server')]
 class StartWebSocketServerCommand extends Command
 {
-    private $webSocketMessaging;
+    private WebSocketMessaging $webSocketMessaging;
 
     public function __construct(WebSocketMessaging $webSocketMessaging)
     {

--- a/src/Event/TransactionCategorizedEvent.php
+++ b/src/Event/TransactionCategorizedEvent.php
@@ -9,7 +9,7 @@ class TransactionCategorizedEvent extends Event
 {
     public const NAME = 'transaction.categorized';
 
-    protected $transaction;
+    protected Transaction $transaction;
 
     public function __construct(Transaction $transaction)
     {


### PR DESCRIPTION
# PR 4/11: Fix PHPStan level 6 errors in an event, an argument resolver, and 3 commands

**Branch:** `phpstan-level-6-commands-misc`
**Base branch:** `phpstan-level-6-events-fixtures`
**Files changed (5):** `src/Event/TransactionCategorizedEvent.php`, `src/ArgumentResolver/RequestParameterValueResolver.php`, `src/Command/ExportModulImmoDataCommand.php`, `src/Command/CategorizeTransactionsCommand.php`, `src/Command/StartWebSocketServerCommand.php`

## Summary

Adds the missing property, parameter, and return types PHPStan level 6 flags in these five files (7 errors total).

## Details and reasoning

**`TransactionCategorizedEvent::$transaction`** — Native `Transaction` type hint. Same single-property, constructor-assigned pattern as every other event fixed in PR 3.

**`RequestParameterValueResolver::resolve()`** — Documented as `iterable<int, bool|string>`. This implements Symfony's `ValueResolverInterface`, and every return path in the method is one of `[]`, `[boolval($value)]`, or `[strval($value)]` — so the yielded values are always `bool` or `string`. I used the union `bool|string` rather than splitting into two overload-style docblocks, since PHPStan's generic iterable syntax doesn't support conditional return typing here and the union accurately describes what any given call can yield.

**`ExportModulImmoDataCommand::createRecord()`** — Added `array $data` (with `@param array<string, mixed> $data`, since it's one decoded-JSON record accessed by string keys like `'date'` and by the `$keyword` parameter) and `string $keyword`. Both parameters were completely untyped before. `$keyword` is always one of two hardcoded string literals passed at the two call sites in `execute()` (`'interests_month'`, `'capital_month'`), so `string` is the natural and only type it's ever called with.

**`CategorizeTransactionsCommand::$transactionCategorizer`** — Native `TransactionCategorizer` type (always set in the constructor, never reassigned).

**`CategorizeTransactionsCommand::$output`** — Native `?OutputInterface` (nullable, defaulting to `null`), *not* non-nullable. This one needed care: unlike `$transactionCategorizer`, `$output` is never set in the constructor — it's only assigned inside `execute()`. The existing code in `onTransactionCategorized()` already guards it with `if ($this->output)`, which only makes sense if the property can genuinely be unset (e.g., if the event fires before `execute()` runs, or in a context where this command object exists but hasn't executed yet). Making it nullable preserves that existing defensive check instead of silently invalidating it.

**`StartWebSocketServerCommand::$webSocketMessaging`** — Native `WebSocketMessaging` type hint (always set in the constructor).

## Verification

```
vendor/bin/phpstan analyse src/Event/TransactionCategorizedEvent.php \
  src/ArgumentResolver/RequestParameterValueResolver.php \
  src/Command/ExportModulImmoDataCommand.php \
  src/Command/CategorizeTransactionsCommand.php \
  src/Command/StartWebSocketServerCommand.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run: exactly these 7 errors disappeared, no new errors introduced.
```
