### PR TITLE
PR 5/11: Fix PHPStan level 6 errors in 5 repository classes (batch 1)

### DIFF
--- a/src/Repository/SettingsRepository.php
+++ b/src/Repository/SettingsRepository.php
@@ -7,10 +7,12 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * @extends ServiceEntityRepository<Settings>
+ *
  * @method Settings|null find($id, $lockMode = null, $lockVersion = null)
- * @method Settings|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Settings|null findOneBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null)
  * @method Settings[]    findAll()
- * @method Settings[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method Settings[]    findBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null, $limit = null, $offset = null)
  */
 class SettingsRepository extends ServiceEntityRepository
 {

--- a/src/Repository/SubCategoryRepository.php
+++ b/src/Repository/SubCategoryRepository.php
@@ -7,10 +7,12 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * @extends ServiceEntityRepository<SubCategory>
+ *
  * @method SubCategory|null find($id, $lockMode = null, $lockVersion = null)
- * @method SubCategory|null findOneBy(array $criteria, array $orderBy = null)
+ * @method SubCategory|null findOneBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null)
  * @method SubCategory[]    findAll()
- * @method SubCategory[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method SubCategory[]    findBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null, $limit = null, $offset = null)
  */
 class SubCategoryRepository extends ServiceEntityRepository
 {
@@ -22,7 +24,7 @@ class SubCategoryRepository extends ServiceEntityRepository
     /**
      * @return SubCategory[] Returns an array of SubCategory objects
      */
-    public function findByTransactionType($value)
+    public function findByTransactionType(string $value)
     {
         return $this->createQueryBuilder('s')
             ->innerJoin('s.topCategory', 't', 'WITH', 't.transactionType = ?1')
@@ -36,7 +38,7 @@ class SubCategoryRepository extends ServiceEntityRepository
     /**
      * @return SubCategory[] Returns an array of SubCategory objects
      */
-    public function findByNameAndTransactionType($name, $type)
+    public function findByNameAndTransactionType(string $name, string $type)
     {
         return $this->createQueryBuilder('s')
             ->innerJoin('s.topCategory', 't', 'WITH', 't.transactionType = ?1')

--- a/src/Repository/SubCategoryTransactionRuleRepository.php
+++ b/src/Repository/SubCategoryTransactionRuleRepository.php
@@ -7,10 +7,12 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * @extends ServiceEntityRepository<SubCategoryTransactionRule>
+ *
  * @method SubCategoryTransactionRule|null find($id, $lockMode = null, $lockVersion = null)
- * @method SubCategoryTransactionRule|null findOneBy(array $criteria, array $orderBy = null)
+ * @method SubCategoryTransactionRule|null findOneBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null)
  * @method SubCategoryTransactionRule[]    findAll()
- * @method SubCategoryTransactionRule[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method SubCategoryTransactionRule[]    findBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null, $limit = null, $offset = null)
  */
 class SubCategoryTransactionRuleRepository extends ServiceEntityRepository
 {

--- a/src/Repository/TopCategoryRepository.php
+++ b/src/Repository/TopCategoryRepository.php
@@ -7,10 +7,12 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * @extends ServiceEntityRepository<TopCategory>
+ *
  * @method TopCategory|null find($id, $lockMode = null, $lockVersion = null)
- * @method TopCategory|null findOneBy(array $criteria, array $orderBy = null)
+ * @method TopCategory|null findOneBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null)
  * @method TopCategory[]    findAll()
- * @method TopCategory[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method TopCategory[]    findBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null, $limit = null, $offset = null)
  */
 class TopCategoryRepository extends ServiceEntityRepository
 {

--- a/src/Repository/TransactionRepository.php
+++ b/src/Repository/TransactionRepository.php
@@ -11,10 +11,12 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * @extends ServiceEntityRepository<Transaction>
+ *
  * @method Transaction|null find($id, $lockMode = null, $lockVersion = null)
- * @method Transaction|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Transaction|null findOneBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null)
  * @method Transaction[]    findAll()
- * @method Transaction[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method Transaction[]    findBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null, $limit = null, $offset = null)
  */
 class TransactionRepository extends ServiceEntityRepository
 {


### PR DESCRIPTION
# PR 5/11: Fix PHPStan level 6 errors in 5 repository classes (batch 1)

**Branch:** `phpstan-level-6-repositories-1`
**Base branch:** `phpstan-level-6-commands-misc`
**Files changed (5):** `src/Repository/SubCategoryRepository.php`, `src/Repository/TransactionRepository.php`, `src/Repository/TopCategoryRepository.php`, `src/Repository/SubCategoryTransactionRuleRepository.php`, `src/Repository/SettingsRepository.php`

## Summary

Adds the missing generic type annotations PHPStan level 6 flags in five Doctrine repository classes (28 errors total). All five share the exact same two problems, which is why I grouped them together rather than pairing them with unrelated files.

## Details and reasoning

**Problem 1 — unspecified `ServiceEntityRepository` generic.** Every repository extends Doctrine's generic `ServiceEntityRepository` class without saying which entity it's for, e.g. `class SubCategoryRepository extends ServiceEntityRepository` with no `@extends` PHPDoc. I added `@extends ServiceEntityRepository<X>` to each class-level docblock, naming the exact entity class the constructor already passes to `parent::__construct($registry, X::class)`. This is purely documenting behavior the code already has — I didn't have to guess or infer anything, since the entity class is passed explicitly one line below.

**Problem 2 — untyped `@method` criteria/orderBy arrays.** Each class has the standard Symfony-generated `@method` PHPDoc block for `find()`/`findOneBy()`/`findAll()`/`findBy()`, and the `findOneBy()`/`findBy()` entries declare bare `array $criteria` / `array $orderBy` parameters. I gave these their conventional Doctrine shapes: `array<string, mixed> $criteria` (field name → value or comparison operand) and `array<string, string>|null $orderBy` (field name → `'ASC'`/`'DESC'`). These are the standard generic types used across Doctrine/Symfony projects for these two parameters — they don't change what the underlying methods (inherited from `ServiceEntityRepository`, not reimplemented in any of these classes) actually accept, only how PHPStan understands the existing `@method` declarations.

**`SubCategoryRepository`'s own methods** — this one had two additional errors beyond the shared pattern:
- `findByTransactionType($value)` → `findByTransactionType(string $value)`. Inside the method, `$value` is bound to `t.transactionType` in the query, which is always one of the `App\Entity\TransactionType` string constants (`'Expenses'`/`'Revenues'`).
- `findByNameAndTransactionType($name, $type)` → both parameters typed `string`. `$name` is compared against `s.name` (a string-typed `SubCategory` property) and `$type` against `t.transactionType`, same reasoning as above.

Neither method currently has a call site anywhere in `src/`, `tests/`, or the Twig templates (I grepped for both method names project-wide to confirm), so I derived the parameter types from how they're used inside the query builder rather than from a caller — there was no ambiguity since both are compared directly to known string-typed fields.

## Verification

```
vendor/bin/phpstan analyse src/Repository/SubCategoryRepository.php \
  src/Repository/TransactionRepository.php \
  src/Repository/TopCategoryRepository.php \
  src/Repository/SubCategoryTransactionRuleRepository.php \
  src/Repository/SettingsRepository.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run: exactly these 28 errors disappeared, no new errors introduced.
```
