### PR TITLE
PR 6/11: Fix PHPStan level 6 errors in 2 repositories and the FilterForm classes

### DIFF
--- a/src/FilterForm/SubCategoryFilterTypeTrait.php
+++ b/src/FilterForm/SubCategoryFilterTypeTrait.php
@@ -7,6 +7,9 @@ use Spiriit\Bundle\FormFilterBundle\Filter\Doctrine\ORMQuery;
 
 trait SubCategoryFilterTypeTrait
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function getSubCategoryFilterTypeOptions(): array
     {
         return [

--- a/src/FilterForm/SubCategoryTransactionRuleFilterType.php
+++ b/src/FilterForm/SubCategoryTransactionRuleFilterType.php
@@ -9,11 +9,14 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @extends AbstractType<array<string, mixed>>
+ */
 class SubCategoryTransactionRuleFilterType extends AbstractType
 {
     use SubCategoryFilterTypeTrait;
 
-    private $translator;
+    private TranslatorInterface $translator;
 
     public function __construct(TranslatorInterface $translator)
     {

--- a/src/FilterForm/TransactionFilterType.php
+++ b/src/FilterForm/TransactionFilterType.php
@@ -13,11 +13,14 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @extends AbstractType<array<string, mixed>>
+ */
 class TransactionFilterType extends AbstractType
 {
     use SubCategoryFilterTypeTrait;
 
-    private $translator;
+    private TranslatorInterface $translator;
 
     public function __construct(TranslatorInterface $translator)
     {

--- a/src/Repository/AccountRepository.php
+++ b/src/Repository/AccountRepository.php
@@ -9,10 +9,12 @@ use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * @extends ServiceEntityRepository<Account>
+ *
  * @method Account|null find($id, $lockMode = null, $lockVersion = null)
- * @method Account|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Account|null findOneBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null)
  * @method Account[]    findAll()
- * @method Account[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method Account[]    findBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null, $limit = null, $offset = null)
  */
 class AccountRepository extends ServiceEntityRepository
 {

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -10,9 +10,9 @@ use Doctrine\Persistence\ManagerRegistry;
  * @extends ServiceEntityRepository<Tag>
  *
  * @method Tag|null find($id, $lockMode = null, $lockVersion = null)
- * @method Tag|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Tag|null findOneBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null)
  * @method Tag[]    findAll()
- * @method Tag[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method Tag[]    findBy(array<string, mixed> $criteria, array<string, string>|null $orderBy = null, $limit = null, $offset = null)
  */
 class TagRepository extends ServiceEntityRepository
 {


### PR DESCRIPTION
# PR 6/11: Fix PHPStan level 6 errors in 2 repositories and the FilterForm classes

**Branch:** `phpstan-level-6-repositories-2-filterform`
**Base branch:** `phpstan-level-6-repositories-1`
**Files changed (5):** `src/Repository/AccountRepository.php`, `src/Repository/TagRepository.php`, `src/FilterForm/TransactionFilterType.php`, `src/FilterForm/SubCategoryTransactionRuleFilterType.php`, `src/FilterForm/SubCategoryFilterTypeTrait.php`

## Summary

Finishes off the two remaining repositories with this pattern, and fixes the small `App\FilterForm` namespace (3 files, 6 errors). Total: 15 errors.

## Details and reasoning

**`AccountRepository`** — Same fix as PR 5's repository batch: `@extends ServiceEntityRepository<Account>` plus `array<string, mixed>`/`array<string, string>|null` generics on the `@method` criteria/orderBy parameters.

**`TagRepository`** — This one already had the `@extends ServiceEntityRepository<Tag>` tag (someone had partially fixed it already), it just still needed the same `@method` criteria/orderBy generic fix every other repository needed.

**`SubCategoryFilterTypeTrait::getSubCategoryFilterTypeOptions()`** — Documented as `array<string, mixed>`: the returned array mixes a class-string (`'class'`) with closures (`'apply_filter'`, `'group_by'`), so `mixed` is the accurate (not lazy) value type here — there's no single narrower type that covers a class-string and two different closure signatures. This trait is `use`d by both `TransactionFilterType` and `SubCategoryTransactionRuleFilterType`, which is why the original error list showed it twice ("in context of class X") — PHPStan reports a trait's errors once per class that consumes it, but the fix lives in one place.

**`TransactionFilterType` / `SubCategoryTransactionRuleFilterType`** —
- `@extends AbstractType<array<string, mixed>>`. This needed a judgment call: every entity-bound form in `src/Form/` sets `'data_class' => SomeEntity::class` in `configureOptions()`, and for those the natural `TData` is the entity itself (I'll use `@extends AbstractType<Entity>` for those in a later PR). These two `FilterForm` classes are different — neither sets `data_class` anywhere, and Symfony's own documented default when no `data_class` is configured is that the form's underlying data is a plain array. So `array<string, mixed>` isn't a guess, it's what Symfony actually does here, and it's also consistent with the `array<string, mixed> $options` parameter already used throughout `buildForm()`.
- `$translator`: native `TranslatorInterface` type hint, the same constructor-injection fix applied repeatedly to translator-holding classes in earlier PRs.

## Verification

```
vendor/bin/phpstan analyse src/Repository/AccountRepository.php \
  src/Repository/TagRepository.php \
  src/FilterForm/TransactionFilterType.php \
  src/FilterForm/SubCategoryTransactionRuleFilterType.php \
  src/FilterForm/SubCategoryFilterTypeTrait.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run: exactly these 15 errors disappeared, no new errors introduced.
```
