### PR TITLE
PR 7/11: Fix PHPStan level 6 errors in 5 Form classes (batch 1)

### DIFF
--- a/src/Form/FileToParseType.php
+++ b/src/Form/FileToParseType.php
@@ -16,10 +16,13 @@ use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @extends AbstractType<array<string, mixed>>
+ */
 class FileToParseType extends AbstractType
 {
-    private $translator;
-    private $locale;
+    private TranslatorInterface $translator;
+    private string $locale;
 
     public function __construct(TranslatorInterface $translator, RequestStack $requestStack)
     {

--- a/src/Form/SubCategoryTransactionRuleType.php
+++ b/src/Form/SubCategoryTransactionRuleType.php
@@ -13,9 +13,12 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @extends AbstractType<SubCategoryTransactionRule>
+ */
 class SubCategoryTransactionRuleType extends AbstractType
 {
-    private $translator;
+    private TranslatorInterface $translator;
 
     public function __construct(TranslatorInterface $translator)
     {

--- a/src/Form/SubCategoryType.php
+++ b/src/Form/SubCategoryType.php
@@ -11,9 +11,12 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @extends AbstractType<SubCategory>
+ */
 class SubCategoryType extends AbstractType
 {
-    private $translator;
+    private TranslatorInterface $translator;
 
     public function __construct(TranslatorInterface $translator)
     {

--- a/src/Form/TopCategoryType.php
+++ b/src/Form/TopCategoryType.php
@@ -9,6 +9,9 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @extends AbstractType<TopCategory>
+ */
 class TopCategoryType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Form/TransactionType.php
+++ b/src/Form/TransactionType.php
@@ -14,6 +14,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @extends AbstractType<Transaction>
+ */
 class TransactionType extends AbstractType
 {
     private TranslatorInterface $translator;


### PR DESCRIPTION
# PR 7/11: Fix PHPStan level 6 errors in 5 Form classes (batch 1)

**Branch:** `phpstan-level-6-forms-1`
**Base branch:** `phpstan-level-6-repositories-2-filterform`
**Files changed (5):** `src/Form/FileToParseType.php`, `src/Form/SubCategoryType.php`, `src/Form/SubCategoryTransactionRuleType.php`, `src/Form/TransactionType.php`, `src/Form/TopCategoryType.php`

## Summary

Adds the missing `AbstractType` generic parameter (and a couple of related property types) across five `App\Form` classes (9 errors total).

## Details and reasoning

Every one of these classes extends Symfony's generic `AbstractType` without specifying its `TData` type parameter — the same root cause as the two `FilterForm` classes fixed in PR 6, just applied to `src/Form/` this time.

For the four classes that set `'data_class'` in `configureOptions()`, the fix was mechanical and unambiguous — I read the exact class straight out of each one's own `data_class` option, so there was no guessing involved:

- `SubCategoryType` → `AbstractType<SubCategory>` (`'data_class' => SubCategory::class`)
- `SubCategoryTransactionRuleType` → `AbstractType<SubCategoryTransactionRule>` (`'data_class' => SubCategoryTransactionRule::class`)
- `TopCategoryType` → `AbstractType<TopCategory>` (`'data_class' => TopCategory::class`)
- `TransactionType` → `AbstractType<Transaction>` (`'data_class' => Transaction::class`)

**`FileToParseType` is the exception.** It has no `data_class` at all — it's a file-upload form with one unmapped field (`'statement'`, `FileType`, `'mapped' => false`) and one entity-picker field. Per Symfony's own documented default for forms without a `data_class` (the underlying data is a plain array), I used `@extends AbstractType<array<string, mixed>>` — the identical annotation and reasoning I applied to `TransactionFilterType` and `SubCategoryTransactionRuleFilterType` in PR 6, which are in the exact same situation.

**Small related fixes in the same files** (bundled here rather than split into a separate PR, since they're in files already being touched):

- `SubCategoryType::$translator`, `SubCategoryTransactionRuleType::$translator`, `FileToParseType::$translator`: native `TranslatorInterface` type hints — the same constructor-injection pattern fixed throughout this whole PR series.
- `FileToParseType::$locale`: native `string` type hint. It's assigned once in the constructor from `$requestStack->getCurrentRequest()->getLocale()`, and `Request::getLocale()` always returns a `string`.

## Verification

```
vendor/bin/phpstan analyse src/Form/FileToParseType.php \
  src/Form/SubCategoryType.php \
  src/Form/SubCategoryTransactionRuleType.php \
  src/Form/TransactionType.php \
  src/Form/TopCategoryType.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run: exactly these 9 errors disappeared, no new errors introduced.
```
