### PR TITLE
PR 9/11: Fix PHPStan level 6 errors in the FileParser service classes

### DIFF
--- a/src/Services/FileParser/AbstractAccountStatementParser.php
+++ b/src/Services/FileParser/AbstractAccountStatementParser.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\FileParser;
 
+use App\Entity\Transaction;
 use App\Services\TransactionFactory;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -21,6 +22,8 @@ abstract class AbstractAccountStatementParser extends AbstractFileParser
 
     /**
      * @param array{accountId?: string} $options
+     *
+     * @return array<int, Transaction>
      */
     public function parse(string $filepath, array $options): array
     {

--- a/src/Services/FileParser/AbstractFileParser.php
+++ b/src/Services/FileParser/AbstractFileParser.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\FileParser;
 
+use App\Entity\Transaction;
 use App\Services\TransactionFactory;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -29,6 +30,8 @@ abstract class AbstractFileParser
 
     /**
      * The file mime-types allowed for this parser.
+     *
+     * @return array<int, string>
      */
     abstract public function getAllowedMimeTypes(): array;
 
@@ -57,6 +60,10 @@ abstract class AbstractFileParser
 
     /**
      * Use this method to add the parser logic.
+     *
+     * @param array{accountId?: string} $options
+     *
+     * @return array<int, Transaction>
      */
     abstract public function parse(string $filePath, array $options): array;
 }

--- a/src/Services/FileParser/FileParserRegistry.php
+++ b/src/Services/FileParser/FileParserRegistry.php
@@ -23,9 +23,9 @@ class FileParserRegistry
 
     /**
      * @param mixed $name accepts a non-string value on purpose: it is validated
-     *                     (and rejected) at runtime below rather than by the
-     *                     type system, since callers may pass unvalidated
-     *                     route/request input here
+     *                    (and rejected) at runtime below rather than by the
+     *                    type system, since callers may pass unvalidated
+     *                    route/request input here
      */
     public function getFileParser($name): ?AbstractFileParser
     {

--- a/src/Services/FileParser/FileParserRegistry.php
+++ b/src/Services/FileParser/FileParserRegistry.php
@@ -4,6 +4,9 @@ namespace App\Services\FileParser;
 
 class FileParserRegistry
 {
+    /**
+     * @var array<int, AbstractFileParser>
+     */
     private $fileParsers;
 
     public function __construct()
@@ -18,6 +21,12 @@ class FileParserRegistry
         return $this;
     }
 
+    /**
+     * @param mixed $name accepts a non-string value on purpose: it is validated
+     *                     (and rejected) at runtime below rather than by the
+     *                     type system, since callers may pass unvalidated
+     *                     route/request input here
+     */
     public function getFileParser($name): ?AbstractFileParser
     {
         if (!is_string($name)) {
@@ -33,6 +42,9 @@ class FileParserRegistry
         return null;
     }
 
+    /**
+     * @return array<int, AbstractFileParser>
+     */
     public function getFileParsers(?string $fileType = null): array
     {
         if ($fileType) {

--- a/src/Services/FileParser/Traits/CsvFileParserTrait.php
+++ b/src/Services/FileParser/Traits/CsvFileParserTrait.php
@@ -6,6 +6,9 @@ use App\Services\FileParser\AbstractFileParser;
 
 trait CsvFileParserTrait
 {
+    /**
+     * @return array<int, string>
+     */
     public function getAllowedMimeTypes(): array
     {
         return [

--- a/src/Services/FileParser/Traits/PdfFileParserTrait.php
+++ b/src/Services/FileParser/Traits/PdfFileParserTrait.php
@@ -6,6 +6,9 @@ use App\Services\FileParser\AbstractFileParser;
 
 trait PdfFileParserTrait
 {
+    /**
+     * @return array<int, string>
+     */
     public function getAllowedMimeTypes(): array
     {
         return [


### PR DESCRIPTION
# PR 9/11: Fix PHPStan level 6 errors in the FileParser service classes

**Branch:** `phpstan-level-6-fileparser`
**Base branch:** `phpstan-level-6-forms-2-tests-misc`
**Files changed (5):** `src/Services/FileParser/AbstractFileParser.php`, `src/Services/FileParser/FileParserRegistry.php`, `src/Services/FileParser/AbstractAccountStatementParser.php`, `src/Services/FileParser/Traits/PdfFileParserTrait.php`, `src/Services/FileParser/Traits/CsvFileParserTrait.php`

## Summary

Adds the missing types across the file-parsing abstraction (12 errors total). One fix here (`FileParserRegistry::getFileParser()`) is worth reading closely — it's a case where the "obvious" native type hint would have introduced a new PHPStan error instead of fixing one.

## Details and reasoning

**`AbstractFileParser::getAllowedMimeTypes()`** — `array<int, string>`. Every implementation across this codebase (including both traits fixed below) returns a plain list of mime-type string literals.

**`AbstractFileParser::parse()` (abstract declaration) and its override in `AbstractAccountStatementParser`** — Documented `$options` as `array{accountId?: string}`, copied onto the abstract declaration from the concrete override (which already had this exact shape documented, just not propagated up to the parent). The return type, `array<int, Transaction>`, I traced through the actual implementation: `AbstractAccountStatementParser::parse()` only ever pushes `$this->transactionFactory->createFromArray($result)` — which returns `Transaction` — onto the results array, so this isn't a guess.

**`FileParserRegistry::$fileParsers`** — `array<int, AbstractFileParser>`, matching exactly what `addFileParser()` pushes onto it.

**`FileParserRegistry::getFileParser($name)` — the one that needed real care.** My first instinct was to type-hint `$name` natively as `string`, since every current caller (`TransactionImportController`, both call sites) already passes a `string`. But the method body has:
```php
if (!is_string($name)) {
    throw new \Exception(...);
}
```
If I'd added a native `string $name` type hint, that runtime check becomes unreachable — PHPStan would then flag a *brand new* error ("Call to function is_string() with string will always evaluate to true"), which is the exact same class of pre-existing bug I later found for real in `WebSocketMessageHandlerRegistry.php` (fixed in a separate PR, since that one's a genuine bug rather than a types-only fix). Swapping one PHPStan error for another wouldn't count as progress, and more importantly it would silently delete a runtime safety check that's clearly intentional (it exists specifically to reject non-string input with a clear exception rather than a fatal type error). Instead, I typed it `@param mixed $name`, which documents reality exactly: this method is designed to accept and validate untrusted input at runtime, not to assume its caller already validated it.

**`FileParserRegistry::getFileParsers()`** — `array<int, AbstractFileParser>` return type, matching the property it reads from (optionally passed through `array_filter()`, which narrows the set but not the element type).

**`PdfFileParserTrait::getAllowedMimeTypes()` / `CsvFileParserTrait::getAllowedMimeTypes()`** — Same `array<int, string>` fix, same reasoning as the abstract declaration. Each trait is `use`d by several parser classes (the PDF trait by N26/Boursorama/CaisseEpargne/CreditMutuel, the CSV trait by the Nbc parsers), which is why the original error list showed several "in context of class X" entries per trait — fixing the trait once resolves all of them.

## Verification

```
vendor/bin/phpstan analyse src/Services/FileParser/AbstractFileParser.php \
  src/Services/FileParser/FileParserRegistry.php \
  src/Services/FileParser/AbstractAccountStatementParser.php \
  src/Services/FileParser/Traits/PdfFileParserTrait.php \
  src/Services/FileParser/Traits/CsvFileParserTrait.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run: exactly these 12 errors disappeared, no new errors introduced.
```
