### PR TITLE
PR 10/11: Fix PHPStan level 6 errors in the Exporter and WebSocketMessageHandler services

### DIFF
--- a/src/Services/Exporter/CsvExporter.php
+++ b/src/Services/Exporter/CsvExporter.php
@@ -19,7 +19,7 @@ class CsvExporter
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param array<array-key, mixed> $input
      */
     private function arrayToCsvString(array $input, string $delimiter = ',', string $enclosure = '"'): string
     {

--- a/src/Services/Exporter/ElasticsearchExporter.php
+++ b/src/Services/Exporter/ElasticsearchExporter.php
@@ -8,6 +8,7 @@ use App\Event\TransactionsExportedEvent;
 use App\Event\TransactionsExportingEvent;
 use App\Services\ConnectionKeeper;
 use Doctrine\ORM\EntityManagerInterface;
+use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
 use React\EventLoop\LoopInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -17,10 +18,14 @@ class ElasticsearchExporter
 {
     private string $elasticsearchHost;
     private string $elasticsearchIndex;
-    private $entityManager;
+    private EntityManagerInterface $entityManager;
+
+    /**
+     * @var Client
+     */
     private $client;
-    private $dispatcher;
-    private $connectionKeeper;
+    private EventDispatcherInterface $dispatcher;
+    private ConnectionKeeper $connectionKeeper;
 
     public function __construct(
         EventDispatcherInterface $dispatcher,

--- a/src/Services/WebSocketMessageHandler/AbstractWebSocketMessageHandler.php
+++ b/src/Services/WebSocketMessageHandler/AbstractWebSocketMessageHandler.php
@@ -7,6 +7,9 @@ use React\EventLoop\LoopInterface;
 
 abstract class AbstractWebSocketMessageHandler
 {
+    /**
+     * @var \SplObjectStorage<ConnectionInterface, mixed>
+     */
     protected \SplObjectStorage $clients;
 
     public function __construct()
@@ -27,7 +30,10 @@ abstract class AbstractWebSocketMessageHandler
         $this->doHandle($connection, $loop);
     }
 
-    protected function sendMessage(ConnectionInterface $connection, string $topic, ?array $data = null): void
+    /**
+     * @param array<string, mixed>|int|string|null $data
+     */
+    protected function sendMessage(ConnectionInterface $connection, string $topic, array|int|string|null $data = null): void
     {
         $connection->send(json_encode([
             'topic' => $topic,

--- a/src/Services/WebSocketMessageHandler/ExportTransactionsHandler.php
+++ b/src/Services/WebSocketMessageHandler/ExportTransactionsHandler.php
@@ -80,6 +80,9 @@ class ExportTransactionsHandler extends AbstractWebSocketMessageHandler
         }
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Services/WebSocketMessageHandler/WebSocketMessageHandlerRegistry.php
+++ b/src/Services/WebSocketMessageHandler/WebSocketMessageHandlerRegistry.php
@@ -23,10 +23,6 @@ class WebSocketMessageHandlerRegistry
 
     public function getHandler(string $trigger): AbstractWebSocketMessageHandler
     {
-        if (!is_string($trigger)) {
-            throw new \Exception(sprintf('Expected argument of type "string", "%s" given', is_object($trigger) ? get_class($trigger) : gettype($trigger)));
-        }
-
         if (!isset($this->handlers[$trigger])) {
             throw new \InvalidArgumentException(sprintf('Could not load handler "%s". Available handlers are %s', $trigger, implode(', ', array_keys($this->handlers))));
         }


### PR DESCRIPTION
# PR 10/11: Fix PHPStan level 6 errors in the Exporter and WebSocketMessageHandler services

**Branch:** `phpstan-level-6-exporter-websocket`
**Base branch:** `phpstan-level-6-fileparser`
**Files changed (5):** `src/Services/Exporter/ElasticsearchExporter.php`, `src/Services/Exporter/CsvExporter.php`, `src/Services/WebSocketMessageHandler/ExportTransactionsHandler.php`, `src/Services/WebSocketMessageHandler/WebSocketMessageHandlerRegistry.php`, `src/Services/WebSocketMessageHandler/AbstractWebSocketMessageHandler.php`

## Summary

Unlike the previous nine PRs, three of these five files had real type **mismatches** flagged (`argument.type` / `function.alreadyNarrowedType`), not just missing annotations. These needed a judgment call about whether the bug was in the caller or the declaration, so I've written up each one in more detail than usual.

## Details and reasoning

**`CsvExporter::arrayToCsvString($input)`** — Its existing PHPDoc claimed `array<string, mixed>` (associative), but it's called with two different shapes: `Transaction::toArray()` (genuinely associative) *and* the CSV header row, which is a plain numeric list of column-name strings. `fputcsv()` doesn't care about array keys at all — it only writes the values in order — so the declared type was simply too narrow for how the method is legitimately used both ways. I widened it to `array<array-key, mixed>`, which accepts both shapes without picking a side or changing either call site.

**`ElasticsearchExporter`** — `$entityManager`, `$dispatcher`, and `$connectionKeeper` got native type hints (`EntityManagerInterface`, `EventDispatcherInterface`, `ConnectionKeeper`) since all three are unconditionally assigned in the constructor. `$client` deliberately stayed PHPDoc-only (`@var Client`, no native type hint): it's only ever assigned inside `exportAllSync()` / `exportAllAsync()`, never the constructor. If I'd added a native non-nullable `Client` type hint, a direct call to the public `exportOne()` method (before either of those two methods runs) would throw "Typed property must not be accessed before initialization" instead of the current (already slightly broken, but not newly broken by me) `Call to a member function on null`. Same reasoning as the Doctrine `Collection` properties in PR 1: don't let a type annotation change a runtime failure mode.

**`AbstractWebSocketMessageHandler::$clients`** — `SplObjectStorage<ConnectionInterface, mixed>`. `attach()` is only ever called with a single argument (the connection), so the storage's "attached data" slot (`TData`) is never actually used — `mixed` documents that honestly without asserting a type that's never populated.

**`AbstractWebSocketMessageHandler::sendMessage($data)` — the real bug in this PR.** The signature declared `?array $data`, but I traced every call site across *both* `WebSocketMessageHandler` subclasses (`ExportTransactionsHandler` and `CategorizeTransactionsHandler`) and found it's actually called with: arrays (multiple shapes), an `int` (`TransactionsExportingEvent::getTransactionCount()`), a `string` (a translated error message), and no third argument at all. PHPStan caught two of those mismatches as hard compile errors in `ExportTransactionsHandler`. I had two options: wrap the int/string call sites in throwaway single-key arrays to fit the existing `?array` contract, or widen the contract to match reality. I chose to widen it, to `array<string, mixed>|int|string|null`, because wrapping would change the JSON payload structure sent over the WebSocket connection (`{"topic": ..., "data": ...}` — the `data` value's shape is presumably meaningful to whatever JS client reads it), and I have no visibility into the frontend code to know that's safe. Widening the type changes zero runtime behavior; it only makes the existing behavior type-check.

**`ExportTransactionsHandler::getSubscribedEvents()`** — `array<string, string>` return type, matching its literal `EventName::NAME => 'methodName'` array.

**`WebSocketMessageHandlerRegistry::getHandler()`** — Removed a dead `is_string($trigger)` runtime guard entirely (rather than typing around it). This looks like the identical defensive pattern I preserved in `FileParserRegistry::getFileParser()` (PR 9), but it's a different situation: here the parameter is *already* natively typed `string $trigger`, so the guard can never be false — PHPStan even narrows `$trigger` to `*NEVER*` inside the dead `if` block, confirming it's unreachable. This is leftover code from before the parameter had a type hint (`FileParserRegistry`'s equivalent method never got one, which is exactly why I kept its guard). Deleting unreachable code here isn't a "make the type checker happy" workaround — it's removing genuinely dead code that the type system now proves can't execute.

## Verification

```
vendor/bin/phpstan analyse src/Services/Exporter/ElasticsearchExporter.php \
  src/Services/Exporter/CsvExporter.php \
  src/Services/WebSocketMessageHandler/ExportTransactionsHandler.php \
  src/Services/WebSocketMessageHandler/WebSocketMessageHandlerRegistry.php \
  src/Services/WebSocketMessageHandler/AbstractWebSocketMessageHandler.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# Full-project run: exactly these 12 errors disappeared, no new errors introduced.
```
