### PR TITLE
PR 11/11 (final): Fix PHPStan level 6 errors in TransactionCategorizer, TransactionFactory, and RuleChecker

### DIFF
--- a/src/Services/RuleChecker.php
+++ b/src/Services/RuleChecker.php
@@ -95,6 +95,8 @@ class RuleChecker
     }
 
     /**
+     * @param SubCategoryTransactionRule[] $rules
+     *
      * @return SubCategoryTransactionRule[]
      */
     private function filterRulesWithHighestPriorities(array $rules): array

--- a/src/Services/TransactionCategorizer.php
+++ b/src/Services/TransactionCategorizer.php
@@ -8,6 +8,7 @@ use App\Event\TransactionCategoryChangedEvent;
 use App\Event\TransactionMatchesMultipleRulesEvent;
 use App\Event\TransactionsCategorizedEvent;
 use App\Exception\TransactionMatchesMultipleRulesException;
+use App\Repository\TransactionRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use React\EventLoop\LoopInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -16,17 +17,20 @@ class TransactionCategorizer
 {
     private RuleChecker $ruleChecker;
     private EntityManagerInterface $entityManager;
+    private TransactionRepository $transactionRepository;
     private EventDispatcherInterface $dispatcher;
     private ConnectionKeeper $connectionKeeper;
 
     public function __construct(
         RuleChecker $ruleChecker,
         EntityManagerInterface $entityManager,
+        TransactionRepository $transactionRepository,
         EventDispatcherInterface $dispatcher,
         ConnectionKeeper $connectionKeeper,
     ) {
         $this->ruleChecker = $ruleChecker;
         $this->entityManager = $entityManager;
+        $this->transactionRepository = $transactionRepository;
         $this->dispatcher = $dispatcher;
         $this->connectionKeeper = $connectionKeeper;
     }
@@ -65,10 +69,7 @@ class TransactionCategorizer
 
     public function categorizeAllSync(): void
     {
-        $transactions = $this->entityManager
-            ->getRepository(Transaction::class)
-            ->findAllNotManuallyCategorized()
-        ;
+        $transactions = $this->transactionRepository->findAllNotManuallyCategorized();
 
         foreach ($transactions as $transaction) {
             $this->categorizeOne($transaction);
@@ -103,10 +104,7 @@ class TransactionCategorizer
         $this->entityManager->clear();
         $this->ruleChecker->setRules();
 
-        $transactions = $this->entityManager
-            ->getRepository(Transaction::class)
-            ->findAllNotManuallyCategorized()
-        ;
+        $transactions = $this->transactionRepository->findAllNotManuallyCategorized();
 
         $this->categorizeInNextTick($loop, $transactions);
     }

--- a/src/Services/TransactionFactory.php
+++ b/src/Services/TransactionFactory.php
@@ -14,6 +14,9 @@ class TransactionFactory
         $this->accountRepository = $accountRepository;
     }
 
+    /**
+     * @param array<string, mixed> $array
+     */
     public function createFromArray($array): Transaction
     {
         $transaction = new Transaction();


### PR DESCRIPTION
# PR 11/11 (final): Fix PHPStan level 6 errors in TransactionCategorizer, TransactionFactory, and RuleChecker

**Branch:** `phpstan-level-6-services-final`
**Base branch:** `phpstan-level-6-exporter-websocket`
**Files changed (3):** `src/Services/TransactionCategorizer.php`, `src/Services/TransactionFactory.php`, `src/Services/RuleChecker.php`

## Summary

This clears the last 4 remaining PHPStan level 6 errors in the project. After this PR, `vendor/bin/phpstan analyse --no-progress --memory-limit=-1` reports **"[OK] No errors"** — level 6 is fully clean across `src/` and `tests/`.

## Details and reasoning

**`TransactionCategorizer::categorizeAllSync()` / `categorizeAllAsync()` — the most interesting fix in this whole series.** Both methods called:
```php
$this->entityManager->getRepository(Transaction::class)->findAllNotManuallyCategorized()
```
This repo only has `phpstan/phpstan-symfony` installed, not `phpstan/phpstan-doctrine`. Without the Doctrine-specific extension, PHPStan has no way to know that `Transaction`'s configured repository class is `TransactionRepository` — it can only see `EntityManagerInterface::getRepository()`'s own generic signature, which returns the *generic* `Doctrine\ORM\EntityRepository<Transaction>`. That generic base class doesn't have a `findAllNotManuallyCategorized()` method — only `TransactionRepository`, a subclass, does. This isn't a false positive from PHPStan; it's a genuine static-typing gap that the code was quietly relying on PHP's dynamic method dispatch to paper over (at runtime, Doctrine really does hand back a `TransactionRepository` instance, so the code works — but nothing in the type signatures says so).

I considered adding `phpstan/phpstan-doctrine` as a new dependency, which would let PHPStan resolve `getRepository()` return types correctly project-wide. I decided against it for this PR series: it's a bigger, riskier change (a new Composer dependency, potentially surfacing a wave of *new* errors elsewhere that would need their own review) than what a "add missing types" cleanup should include, and it isn't the pattern this codebase already uses to solve this exact problem elsewhere.

Instead, I applied the pattern already established in `TransactionFactory`, which injects `AccountRepository` directly via its constructor rather than calling `$entityManager->getRepository(Account::class)`. I added `TransactionRepository` as a constructor-injected dependency to `TransactionCategorizer` (autowired automatically, the same way every other repository in this project already is — no service configuration changes needed) and replaced both `getRepository()` call chains with direct calls on `$this->transactionRepository`. This isn't just a type-checker workaround: Doctrine's `EntityManager` caches repository instances internally, so `$this->transactionRepository` and what `$entityManager->getRepository(Transaction::class)` would have returned are literally the same object. Zero behavior change, just a statically-typed path to it instead of a dynamically-resolved one.

**`RuleChecker::filterRulesWithHighestPriorities()`** — Added the missing `@param SubCategoryTransactionRule[] $rules` docblock. Every other private method in this class that takes the same `$rules` parameter (`getBestRule()`, `getHighestPriorityValue()`, `allRulesHaveTheSameSubCategory()`) already has this exact annotation — this one method was simply missed when the others were annotated.

**`TransactionFactory::createFromArray()`** — Documented `$array` as `array<string, mixed>`. Inside the method it's accessed by string keys (`'accountId'`, `'account'`, `'value'`, `'date'`, `'label'`) holding mixed value types (a float amount, several date/label/name strings) — exactly what this type describes. I didn't need to guess: every caller (`AbstractAccountStatementParser::parse()`, fixed in PR 9) passes exactly this shape.

## Verification

```
vendor/bin/phpstan analyse src/Services/TransactionCategorizer.php \
  src/Services/TransactionFactory.php \
  src/Services/RuleChecker.php --no-progress --memory-limit=-1
# 0 errors

vendor/bin/phpstan analyse --no-progress --memory-limit=-1
# [OK] No errors — PHPStan level 6 is fully clean project-wide.
```

## What's left after this PR

Nothing — this was the last of 11 stacked PRs covering all 53 files that had level 6 errors (123 errors total across the series). Once PR 1 is merged into `phpstan-level-6`, each subsequent PR should be merged in order (2 → 3 → ... → 11), since each branch is stacked on the previous one's tip.
